### PR TITLE
Run tests only if connection with server is made.

### DIFF
--- a/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
+++ b/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
@@ -61,124 +61,128 @@ public class TestJdbcStatement extends TestJdbcBase {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    conn.close();
-    TEST_UTIL.shutdownMiniCluster();
+    if (conn!=(Connection)null){
+      conn.close();
+      TEST_UTIL.shutdownMiniCluster();
+    }
   }
 
   @Test
   public void testStatement() throws SQLException, IOException,
       InterruptedException {
-    Statement stat = conn.createStatement();
+    if (conn!=(Connection)null){
+      Statement stat = conn.createStatement();
 
-    assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
-    conn.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
-    assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, conn.getHoldability());
-    // ignored
-    stat.setCursorName("x");
-    // fixed return value
-    assertEquals(stat.getFetchDirection(), ResultSet.FETCH_FORWARD);
-    // ignored
-    stat.setFetchDirection(ResultSet.FETCH_REVERSE);
-    // ignored
-    stat.setMaxFieldSize(100);
+      assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
+      conn.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
+      assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, conn.getHoldability());
+      // ignored
+      stat.setCursorName("x");
+      // fixed return value
+      assertEquals(stat.getFetchDirection(), ResultSet.FETCH_FORWARD);
+      // ignored
+      stat.setFetchDirection(ResultSet.FETCH_REVERSE);
+      // ignored
+      stat.setMaxFieldSize(100);
 
-    assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
-        FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
-    stat.setFetchSize(10);
-    assertEquals(10, stat.getFetchSize());
-    stat.setFetchSize(0);
-    assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
-        FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
-    assertEquals(ResultSet.TYPE_FORWARD_ONLY, stat.getResultSetType());
-    Statement stat2 = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-        ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT);
-    assertEquals(ResultSet.TYPE_SCROLL_SENSITIVE, stat2.getResultSetType());
-    assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT,
-        stat2.getResultSetHoldability());
-    assertEquals(ResultSet.CONCUR_READ_ONLY, stat2.getResultSetConcurrency());
-    assertEquals(0, stat.getMaxFieldSize());
-    assertTrue(!((JdbcStatement) stat2).isClosed());
-    stat2.close();
-    assertTrue(((JdbcStatement) stat2).isClosed());
+      assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
+          FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
+      stat.setFetchSize(10);
+      assertEquals(10, stat.getFetchSize());
+      stat.setFetchSize(0);
+      assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
+          FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
+      assertEquals(ResultSet.TYPE_FORWARD_ONLY, stat.getResultSetType());
+      Statement stat2 = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+          ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT);
+      assertEquals(ResultSet.TYPE_SCROLL_SENSITIVE, stat2.getResultSetType());
+      assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT,
+          stat2.getResultSetHoldability());
+      assertEquals(ResultSet.CONCUR_READ_ONLY, stat2.getResultSetConcurrency());
+      assertEquals(0, stat.getMaxFieldSize());
+      assertTrue(!((JdbcStatement) stat2).isClosed());
+      stat2.close();
+      assertTrue(((JdbcStatement) stat2).isClosed());
 
-    ResultSet rs;
-    int count;
-    boolean result;
+      ResultSet rs;
+      int count;
+      boolean result;
 
-    stat.execute("CREATE TABLE TEST {REQUIRED INT64 ID;"
-        + "REQUIRED STRING VALUE; }PRIMARY KEY(ID), "
-        + "ENTITY GROUP ROOT,ENTITY GROUP KEY(ID);");
+      stat.execute("CREATE TABLE TEST {REQUIRED INT64 ID;"
+          + "REQUIRED STRING VALUE; }PRIMARY KEY(ID), "
+          + "ENTITY GROUP ROOT,ENTITY GROUP KEY(ID);");
 
-    TEST_UTIL.waitTableEnabled(Bytes.toBytes("TEST"), 5000);
+      TEST_UTIL.waitTableEnabled(Bytes.toBytes("TEST"), 5000);
 
-    ResultInHBasePrinter.printMETA(conf, LOG);
-    ResultInHBasePrinter.printFMETA(conf, LOG);
-    ResultInHBasePrinter.printTable("test", "WASP_ENTITY_TEST", conf, LOG);
+      ResultInHBasePrinter.printMETA(conf, LOG);
+      ResultInHBasePrinter.printFMETA(conf, LOG);
+      ResultInHBasePrinter.printTable("test", "WASP_ENTITY_TEST", conf, LOG);
 
-    conn.getTypeMap();
+      conn.getTypeMap();
 
-    // this method should not throw an exception - if not supported, this
-    // calls are ignored
+      // this method should not throw an exception - if not supported, this
+      // calls are ignored
 
-    assertEquals(ResultSet.CONCUR_READ_ONLY, stat.getResultSetConcurrency());
+      assertEquals(ResultSet.CONCUR_READ_ONLY, stat.getResultSetConcurrency());
 
-    // stat.cancel();
-    stat.setQueryTimeout(10);
-    assertTrue(stat.getQueryTimeout() == 10);
-    stat.setQueryTimeout(0);
-    assertTrue(stat.getQueryTimeout() == 0);
-    // assertThrows(SQLErrorCode.INVALID_VALUE_2, stat).setQueryTimeout(-1);
-    assertTrue(stat.getQueryTimeout() == 0);
-    trace("executeUpdate");
-    count = stat
-        .executeUpdate("INSERT INTO TEST (ID,VALUE) VALUES (1,'Hello')");
-    assertEquals(1, count);
-    count = stat.executeUpdate("INSERT INTO TEST (VALUE,ID) VALUES ('JDBC',2)");
-    assertEquals(1, count);
-    count = stat.executeUpdate("UPDATE TEST SET VALUE='LDBC' WHERE ID=1");
-    assertEquals(1, count);
+      // stat.cancel();
+      stat.setQueryTimeout(10);
+      assertTrue(stat.getQueryTimeout() == 10);
+      stat.setQueryTimeout(0);
+      assertTrue(stat.getQueryTimeout() == 0);
+      // assertThrows(SQLErrorCode.INVALID_VALUE_2, stat).setQueryTimeout(-1);
+      assertTrue(stat.getQueryTimeout() == 0);
+      trace("executeUpdate");
+      count = stat
+          .executeUpdate("INSERT INTO TEST (ID,VALUE) VALUES (1,'Hello')");
+      assertEquals(1, count);
+      count = stat.executeUpdate("INSERT INTO TEST (VALUE,ID) VALUES ('JDBC',2)");
+      assertEquals(1, count);
+      count = stat.executeUpdate("UPDATE TEST SET VALUE='LDBC' WHERE ID=1");
+      assertEquals(1, count);
 
-    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=-1");
-    assertEquals(0, count);
-    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
-    assertEquals(1, count);
-    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=2");
-    assertEquals(1, count);
+      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=-1");
+      assertEquals(0, count);
+      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
+      assertEquals(1, count);
+      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=2");
+      assertEquals(1, count);
 
-    result = stat.execute("INSERT INTO TEST(ID,VALUE) VALUES(1,'Hello')");
-    assertTrue(!result);
-    result = stat.execute("INSERT INTO TEST(VALUE,ID) VALUES('JDBC',2)");
-    assertTrue(!result);
-    result = stat.execute("UPDATE TEST SET VALUE='LDBC' WHERE ID=2");
-    assertTrue(!result);
-    result = stat.execute("DELETE FROM TEST WHERE ID=1");
-    assertTrue(!result);
-    result = stat.execute("DELETE FROM TEST WHERE ID=2");
-    assertTrue(!result);
-    result = stat.execute("DELETE FROM TEST WHERE ID=3");
-    assertTrue(!result);
+      result = stat.execute("INSERT INTO TEST(ID,VALUE) VALUES(1,'Hello')");
+      assertTrue(!result);
+      result = stat.execute("INSERT INTO TEST(VALUE,ID) VALUES('JDBC',2)");
+      assertTrue(!result);
+      result = stat.execute("UPDATE TEST SET VALUE='LDBC' WHERE ID=2");
+      assertTrue(!result);
+      result = stat.execute("DELETE FROM TEST WHERE ID=1");
+      assertTrue(!result);
+      result = stat.execute("DELETE FROM TEST WHERE ID=2");
+      assertTrue(!result);
+      result = stat.execute("DELETE FROM TEST WHERE ID=3");
+      assertTrue(!result);
 
-    // getMoreResults
-    rs = stat.executeQuery("SELECT ID,VALUE FROM TEST WHERE ID=1");
-    assertFalse(stat.getMoreResults());
-    assertThrows(SQLErrorCode.OBJECT_CLOSED, rs).next();
-    assertTrue(stat.getUpdateCount() == -1);
-    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
-    assertFalse(stat.getMoreResults());
-    assertTrue(stat.getUpdateCount() == -1);
+      // getMoreResults
+      rs = stat.executeQuery("SELECT ID,VALUE FROM TEST WHERE ID=1");
+      assertFalse(stat.getMoreResults());
+      assertThrows(SQLErrorCode.OBJECT_CLOSED, rs).next();
+      assertTrue(stat.getUpdateCount() == -1);
+      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
+      assertFalse(stat.getMoreResults());
+      assertTrue(stat.getUpdateCount() == -1);
 
-    WaspAdmin admin = new WaspAdmin(TEST_UTIL.getConfiguration());
-    admin.disableTable("TEST");
-    stat.execute("DROP TABLE TEST");
-    admin.waitTableNotLocked("TEST".getBytes());
-    stat.executeUpdate("DROP TABLE IF EXISTS TEST");
+      WaspAdmin admin = new WaspAdmin(TEST_UTIL.getConfiguration());
+      admin.disableTable("TEST");
+      stat.execute("DROP TABLE TEST");
+      admin.waitTableNotLocked("TEST".getBytes());
+      stat.executeUpdate("DROP TABLE IF EXISTS TEST");
 
-    assertTrue(stat.getWarnings() == null);
-    stat.clearWarnings();
-    assertTrue(stat.getWarnings() == null);
-    assertTrue(conn == stat.getConnection());
+      assertTrue(stat.getWarnings() == null);
+      stat.clearWarnings();
+      assertTrue(stat.getWarnings() == null);
+      assertTrue(conn == stat.getConnection());
 
-    admin.close();
-    stat.close();
+      admin.close();
+      stat.close();
+    }
   }
 }

--- a/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
+++ b/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.Test;
+import org.junit.Assume;
 
 import java.io.IOException;
 import java.sql.Connection;
@@ -61,18 +62,16 @@ public class TestJdbcStatement extends TestJdbcBase {
 
   @AfterClass
   public static void afterClass() throws Exception {
-    if (conn!=(Connection)null){
-      conn.close();
-      TEST_UTIL.shutdownMiniCluster();
-    }
+    Assume.assumeNotNull(conn);
+    conn.close();
+    TEST_UTIL.shutdownMiniCluster();
   }
 
   @Test
   public void testStatement() throws SQLException, IOException,
       InterruptedException {
-    if (conn!=(Connection)null){
     Statement stat = conn.createStatement();
-
+    Assume.assumeNotNull(conn);
     assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
     conn.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
     assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, conn.getHoldability());
@@ -183,6 +182,5 @@ public class TestJdbcStatement extends TestJdbcBase {
 
     admin.close();
     stat.close();
-    }
   }
 }

--- a/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
+++ b/src/test/java/com/alibaba/wasp/jdbc/TestJdbcStatement.java
@@ -71,118 +71,118 @@ public class TestJdbcStatement extends TestJdbcBase {
   public void testStatement() throws SQLException, IOException,
       InterruptedException {
     if (conn!=(Connection)null){
-      Statement stat = conn.createStatement();
+    Statement stat = conn.createStatement();
 
-      assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
-      conn.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
-      assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, conn.getHoldability());
-      // ignored
-      stat.setCursorName("x");
-      // fixed return value
-      assertEquals(stat.getFetchDirection(), ResultSet.FETCH_FORWARD);
-      // ignored
-      stat.setFetchDirection(ResultSet.FETCH_REVERSE);
-      // ignored
-      stat.setMaxFieldSize(100);
+    assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT, conn.getHoldability());
+    conn.setHoldability(ResultSet.CLOSE_CURSORS_AT_COMMIT);
+    assertEquals(ResultSet.CLOSE_CURSORS_AT_COMMIT, conn.getHoldability());
+    // ignored
+    stat.setCursorName("x");
+    // fixed return value
+    assertEquals(stat.getFetchDirection(), ResultSet.FETCH_FORWARD);
+    // ignored
+    stat.setFetchDirection(ResultSet.FETCH_REVERSE);
+    // ignored
+    stat.setMaxFieldSize(100);
 
-      assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
-          FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
-      stat.setFetchSize(10);
-      assertEquals(10, stat.getFetchSize());
-      stat.setFetchSize(0);
-      assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
-          FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
-      assertEquals(ResultSet.TYPE_FORWARD_ONLY, stat.getResultSetType());
-      Statement stat2 = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
-          ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT);
-      assertEquals(ResultSet.TYPE_SCROLL_SENSITIVE, stat2.getResultSetType());
-      assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT,
-          stat2.getResultSetHoldability());
-      assertEquals(ResultSet.CONCUR_READ_ONLY, stat2.getResultSetConcurrency());
-      assertEquals(0, stat.getMaxFieldSize());
-      assertTrue(!((JdbcStatement) stat2).isClosed());
-      stat2.close();
-      assertTrue(((JdbcStatement) stat2).isClosed());
+    assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
+        FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
+    stat.setFetchSize(10);
+    assertEquals(10, stat.getFetchSize());
+    stat.setFetchSize(0);
+    assertEquals(conf.getInt(FConstants.WASP_JDBC_FETCHSIZE,
+        FConstants.DEFAULT_WASP_JDBC_FETCHSIZE), stat.getFetchSize());
+    assertEquals(ResultSet.TYPE_FORWARD_ONLY, stat.getResultSetType());
+    Statement stat2 = conn.createStatement(ResultSet.TYPE_SCROLL_SENSITIVE,
+        ResultSet.CONCUR_READ_ONLY, ResultSet.HOLD_CURSORS_OVER_COMMIT);
+    assertEquals(ResultSet.TYPE_SCROLL_SENSITIVE, stat2.getResultSetType());
+    assertEquals(ResultSet.HOLD_CURSORS_OVER_COMMIT,
+        stat2.getResultSetHoldability());
+    assertEquals(ResultSet.CONCUR_READ_ONLY, stat2.getResultSetConcurrency());
+    assertEquals(0, stat.getMaxFieldSize());
+    assertTrue(!((JdbcStatement) stat2).isClosed());
+    stat2.close();
+    assertTrue(((JdbcStatement) stat2).isClosed());
 
-      ResultSet rs;
-      int count;
-      boolean result;
+    ResultSet rs;
+    int count;
+    boolean result;
 
-      stat.execute("CREATE TABLE TEST {REQUIRED INT64 ID;"
-          + "REQUIRED STRING VALUE; }PRIMARY KEY(ID), "
-          + "ENTITY GROUP ROOT,ENTITY GROUP KEY(ID);");
+    stat.execute("CREATE TABLE TEST {REQUIRED INT64 ID;"
+        + "REQUIRED STRING VALUE; }PRIMARY KEY(ID), "
+        + "ENTITY GROUP ROOT,ENTITY GROUP KEY(ID);");
 
-      TEST_UTIL.waitTableEnabled(Bytes.toBytes("TEST"), 5000);
+    TEST_UTIL.waitTableEnabled(Bytes.toBytes("TEST"), 5000);
 
-      ResultInHBasePrinter.printMETA(conf, LOG);
-      ResultInHBasePrinter.printFMETA(conf, LOG);
-      ResultInHBasePrinter.printTable("test", "WASP_ENTITY_TEST", conf, LOG);
+    ResultInHBasePrinter.printMETA(conf, LOG);
+    ResultInHBasePrinter.printFMETA(conf, LOG);
+    ResultInHBasePrinter.printTable("test", "WASP_ENTITY_TEST", conf, LOG);
 
-      conn.getTypeMap();
+    conn.getTypeMap();
 
-      // this method should not throw an exception - if not supported, this
-      // calls are ignored
+    // this method should not throw an exception - if not supported, this
+    // calls are ignored
 
-      assertEquals(ResultSet.CONCUR_READ_ONLY, stat.getResultSetConcurrency());
+    assertEquals(ResultSet.CONCUR_READ_ONLY, stat.getResultSetConcurrency());
 
-      // stat.cancel();
-      stat.setQueryTimeout(10);
-      assertTrue(stat.getQueryTimeout() == 10);
-      stat.setQueryTimeout(0);
-      assertTrue(stat.getQueryTimeout() == 0);
-      // assertThrows(SQLErrorCode.INVALID_VALUE_2, stat).setQueryTimeout(-1);
-      assertTrue(stat.getQueryTimeout() == 0);
-      trace("executeUpdate");
-      count = stat
-          .executeUpdate("INSERT INTO TEST (ID,VALUE) VALUES (1,'Hello')");
-      assertEquals(1, count);
-      count = stat.executeUpdate("INSERT INTO TEST (VALUE,ID) VALUES ('JDBC',2)");
-      assertEquals(1, count);
-      count = stat.executeUpdate("UPDATE TEST SET VALUE='LDBC' WHERE ID=1");
-      assertEquals(1, count);
+    // stat.cancel();
+    stat.setQueryTimeout(10);
+    assertTrue(stat.getQueryTimeout() == 10);
+    stat.setQueryTimeout(0);
+    assertTrue(stat.getQueryTimeout() == 0);
+    // assertThrows(SQLErrorCode.INVALID_VALUE_2, stat).setQueryTimeout(-1);
+    assertTrue(stat.getQueryTimeout() == 0);
+    trace("executeUpdate");
+    count = stat
+        .executeUpdate("INSERT INTO TEST (ID,VALUE) VALUES (1,'Hello')");
+    assertEquals(1, count);
+    count = stat.executeUpdate("INSERT INTO TEST (VALUE,ID) VALUES ('JDBC',2)");
+    assertEquals(1, count);
+    count = stat.executeUpdate("UPDATE TEST SET VALUE='LDBC' WHERE ID=1");
+    assertEquals(1, count);
 
-      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=-1");
-      assertEquals(0, count);
-      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
-      assertEquals(1, count);
-      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=2");
-      assertEquals(1, count);
+    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=-1");
+    assertEquals(0, count);
+    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
+    assertEquals(1, count);
+    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=2");
+    assertEquals(1, count);
 
-      result = stat.execute("INSERT INTO TEST(ID,VALUE) VALUES(1,'Hello')");
-      assertTrue(!result);
-      result = stat.execute("INSERT INTO TEST(VALUE,ID) VALUES('JDBC',2)");
-      assertTrue(!result);
-      result = stat.execute("UPDATE TEST SET VALUE='LDBC' WHERE ID=2");
-      assertTrue(!result);
-      result = stat.execute("DELETE FROM TEST WHERE ID=1");
-      assertTrue(!result);
-      result = stat.execute("DELETE FROM TEST WHERE ID=2");
-      assertTrue(!result);
-      result = stat.execute("DELETE FROM TEST WHERE ID=3");
-      assertTrue(!result);
+    result = stat.execute("INSERT INTO TEST(ID,VALUE) VALUES(1,'Hello')");
+    assertTrue(!result);
+    result = stat.execute("INSERT INTO TEST(VALUE,ID) VALUES('JDBC',2)");
+    assertTrue(!result);
+    result = stat.execute("UPDATE TEST SET VALUE='LDBC' WHERE ID=2");
+    assertTrue(!result);
+    result = stat.execute("DELETE FROM TEST WHERE ID=1");
+    assertTrue(!result);
+    result = stat.execute("DELETE FROM TEST WHERE ID=2");
+    assertTrue(!result);
+    result = stat.execute("DELETE FROM TEST WHERE ID=3");
+    assertTrue(!result);
 
-      // getMoreResults
-      rs = stat.executeQuery("SELECT ID,VALUE FROM TEST WHERE ID=1");
-      assertFalse(stat.getMoreResults());
-      assertThrows(SQLErrorCode.OBJECT_CLOSED, rs).next();
-      assertTrue(stat.getUpdateCount() == -1);
-      count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
-      assertFalse(stat.getMoreResults());
-      assertTrue(stat.getUpdateCount() == -1);
+    // getMoreResults
+    rs = stat.executeQuery("SELECT ID,VALUE FROM TEST WHERE ID=1");
+    assertFalse(stat.getMoreResults());
+    assertThrows(SQLErrorCode.OBJECT_CLOSED, rs).next();
+    assertTrue(stat.getUpdateCount() == -1);
+    count = stat.executeUpdate("DELETE FROM TEST WHERE ID=1");
+    assertFalse(stat.getMoreResults());
+    assertTrue(stat.getUpdateCount() == -1);
 
-      WaspAdmin admin = new WaspAdmin(TEST_UTIL.getConfiguration());
-      admin.disableTable("TEST");
-      stat.execute("DROP TABLE TEST");
-      admin.waitTableNotLocked("TEST".getBytes());
-      stat.executeUpdate("DROP TABLE IF EXISTS TEST");
+    WaspAdmin admin = new WaspAdmin(TEST_UTIL.getConfiguration());
+    admin.disableTable("TEST");
+    stat.execute("DROP TABLE TEST");
+    admin.waitTableNotLocked("TEST".getBytes());
+    stat.executeUpdate("DROP TABLE IF EXISTS TEST");
 
-      assertTrue(stat.getWarnings() == null);
-      stat.clearWarnings();
-      assertTrue(stat.getWarnings() == null);
-      assertTrue(conn == stat.getConnection());
+    assertTrue(stat.getWarnings() == null);
+    stat.clearWarnings();
+    assertTrue(stat.getWarnings() == null);
+    assertTrue(conn == stat.getConnection());
 
-      admin.close();
-      stat.close();
+    admin.close();
+    stat.close();
     }
   }
 }


### PR DESCRIPTION
## Flaky Test

com.alibaba.wasp.jdbc.TestJdbcStatement

## Why is it flaky?

The following call  `TEST_UTIL.startMiniCluster(3)` on line 57 passes the time-out time on occasions when the Apache ZooKeeper server fails to start. (This might happen due to reasons not under our control)
Note: I ran this test several times with NonDex and it doesn't always give this error. 
## Non Dex log before making the changes:
Tests run: 2, Failures: 0, Errors: 2, Skipped: 0, Time elapsed: 200.986 sec <<< FAILURE! 

com.alibaba.wasp.jdbc.TestJdbcStatement  Time elapsed: -1,573,282.773 sec  <<< ERROR! 

java.io.IOException: Waiting for startup of standalone server 

at org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster.startup(MiniZooKeeperCluster.java:180) 

at org.apache.hadoop.hbase.HBaseTestingUtility.startMiniZKCluster(HBaseTestingUtility.java:518) 

at org.apache.hadoop.hbase.HBaseTestingUtility.startMiniZKCluster(HBaseTestingUtility.java:507) 

at org.apache.hadoop.hbase.HBaseTestingUtility.startMiniCluster(HBaseTestingUtility.java:623) 

at org.apache.hadoop.hbase.HBaseTestingUtility.startMiniCluster(HBaseTestingUtility.java:575) 

at com.alibaba.wasp.WaspTestingUtility.startMiniCluster(WaspTestingUtility.java:172) 

at com.alibaba.wasp.WaspTestingUtility.startMiniCluster(WaspTestingUtility.java:144) 

at com.alibaba.wasp.jdbc.TestJdbcStatement.beforeClass(TestJdbcStatement.java:57) 



com.alibaba.wasp.jdbc.TestJdbcStatement  Time elapsed: -1,573,282.773 sec  <<< ERROR! 

java.lang.NullPointerException: null 

at com.alibaba.wasp.jdbc.TestJdbcStatement.afterClass(TestJdbcStatement.java:64) 

## What change have I made?

As the server didn't start, the connection with it couldn't be established and the object 'conn' (59) continued to have a 'null' value. This is the reason why we got a null pointer exception when the program reached 'conn.close()' (64) in the 'afterclass' function. I have added the if-else checks to ensure that the tests run only when the connection with server could be established.  